### PR TITLE
Configure Sealog to run in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:12
+
+WORKDIR /usr/src/app
+
+# Install packages
+COPY package*.json ./
+RUN npm install
+
+# Copy sources
+COPY . .
+
+# Copy configuration files
+COPY config/db_constants.js.dist config/db_constants.js
+COPY config/email_constants.js.dist config/email_constants.js
+COPY config/manifest.js.dist config/manifest.js
+COPY config/path_constants.js.dist config/path_constants.js
+COPY config/secret.js.dist config/secret.js
+
+# Patch the configuration
+RUN sed -i \
+        -e 's,mongodb://localhost:27017/,mongodb://mongo/,' \
+        config/manifest.js
+
+# TODO: Generate a new secret?
+
+# Expose the API port (defined in config/manifest.js)
+EXPOSE 8000
+
+# By default, run in production mode
+CMD [ "npm", "run-script", "start-devel" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ RUN sed -i \
 EXPOSE 8000
 
 # By default, run in production mode
-CMD [ "npm", "run-script", "start-devel" ]
+CMD [ "npm", "run", "start" ]

--- a/config/secret.js.dist
+++ b/config/secret.js.dist
@@ -1,2 +1,5 @@
-//create this with: node -e "console.log(require('crypto').randomBytes(256).toString('base64'));"
-module.exports = '';
+//create this with:
+//node -e "console.log(require('crypto').randomBytes(256).toString('base64'));"
+const secret = '';
+
+module.exports = process.env.SEALOG_SECRET || secret;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,24 @@ services:
     image: oceandatatools/sealog-server
     depends_on:
       - mongo
+
+    environment:
+      # Change this value to something random
+      - SEALOG_SECRET=VDESWM31EC+YQ5bLtrIHxl9dnHH67oGx7aMgm27ALjI=
+
+    # To use the debugger, uncomment the following and the port below and visit
+    # chrome://inspect in the Chrome browser
+    #command: node --inspect-brk=0.0.0.0:9229 server.js
+
     ports:
       - "8000:8000"  # API
+    # - "9229:9229"  # Node debugger
+
+    volumes:
+      - sealog-files:/home/sealog/sealog-files
+    # To use custom configuration files in ./config, uncomment the following:
+    # - ./config:/usr/src/app/config
+
 
   mongo:
     image: mongo:4
@@ -17,5 +33,7 @@ services:
     volumes:
       - database:/data/db
 
+
 volumes:
   database:
+  sealog-files:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.6'
+
+services:
+  sealog-server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: oceandatatools/sealog-server
+    depends_on:
+      - mongo
+    ports:
+      - "8000:8000"  # API
+
+  mongo:
+    image: mongo:4
+    restart: always
+    volumes:
+      - database:/data/db
+
+volumes:
+  database:


### PR DESCRIPTION
This change adds a `Dockerfile` which allows Sealog to be packaged up into a Docker container. It also adds a `docker-compose.yml` file that spins up an instance of Sealog along with an instance of MongoDB:

```
$ docker-compose up --build
...
sealog-server_1  | ✅  Server is listening on http://0.0.0.0:8000
```

This makes it very easy to deploy Sealog. Also, if pre-build containers are pushed to Docker Hub, it will be possible to run any historic version of Sealog on a snapshot of a database, which is great for backwards compatibility.

This change works as-is, but it might be worth considering a few improvements, in particular how configuration should work.