### PR TITLE
Fix scoped plugin dependencies

### DIFF
--- a/routes/api/v1/cruises.js
+++ b/routes/api/v1/cruises.js
@@ -193,7 +193,7 @@ const cruiseUpdatePermissionsPayload = Joi.object({
 
 exports.plugin = {
   name: 'routes-api-cruises',
-  dependencies: ['hapi-mongodb', '@hapi/nes'],
+  dependencies: ['hapi-mongodb', 'nes'],
   register: (server, options) => {
 
     server.subscription('/ws/status/newCruises');

--- a/routes/api/v1/custom_vars.js
+++ b/routes/api/v1/custom_vars.js
@@ -43,7 +43,7 @@ const customVarUpdatePayload = Joi.object({
 
 exports.plugin = {
   name: 'routes-api-custom_vars',
-  dependencies: ['hapi-mongodb', '@hapi/nes'],
+  dependencies: ['hapi-mongodb', 'nes'],
   register: (server, options) => {
 
     server.subscription('/ws/status/updateCustomVars');

--- a/routes/api/v1/event_aux_data.js
+++ b/routes/api/v1/event_aux_data.js
@@ -174,7 +174,7 @@ const auxDataSuccessResponse = Joi.object({
 
 exports.plugin = {
   name: 'routes-api-event_aux_data',
-  dependencies: ['hapi-mongodb', '@hapi/nes'],
+  dependencies: ['hapi-mongodb', 'nes'],
   register: (server, options) => {
 
     server.subscription('/ws/status/newEventAuxData');

--- a/routes/api/v1/events.js
+++ b/routes/api/v1/events.js
@@ -225,7 +225,7 @@ const eventUpdatePayload = Joi.object({
 
 exports.plugin = {
   name: 'routes-api-events',
-  dependencies: ['hapi-mongodb', '@hapi/nes'],
+  dependencies: ['hapi-mongodb', 'nes'],
   register: (server, options) => {
 
     server.subscription('/ws/status/newEvents');

--- a/routes/api/v1/lowerings.js
+++ b/routes/api/v1/lowerings.js
@@ -182,7 +182,7 @@ const loweringUpdatePermissionsPayload = Joi.object({
 
 exports.plugin = {
   name: 'routes-api-lowerings',
-  dependencies: ['hapi-mongodb','@hapi/nes'],
+  dependencies: ['hapi-mongodb','nes'],
   register: (server, options) => {
 
     server.subscription('/ws/status/newLowerings');

--- a/routes/default.js
+++ b/routes/default.js
@@ -79,7 +79,7 @@ const filepondFilePayload = Joi.object({
 
 exports.plugin = {
   name: 'routes-default',
-  dependencies: ['hapi-mongodb', '@hapi/inert'],
+  dependencies: ['hapi-mongodb', 'inert'],
   register: (server, options) => {
 
     server.route({

--- a/routes/ws/events.js
+++ b/routes/ws/events.js
@@ -1,6 +1,6 @@
 exports.plugin = {
   name: 'routes-ws-events',
-  dependencies: ['@hapi/nes'],
+  dependencies: ['nes'],
   register: (server, options) => {
 
     server.method('publishNewEvent', ( payload ) => {


### PR DESCRIPTION
Plugins declared dependencies on packages in the @hapi scope, but dependency resolution works only with the unscoped package name.

I'm curious if it works on your system as-is. I'm trying to debug it further down the stack:

* https://stackoverflow.com/questions/61084503
* https://github.com/hapijs/hapi/issues/4088

