### PR TITLE
Fix async emailTransporter initialization and add sendMail guard

### DIFF
--- a/config/email_settings.js.dist
+++ b/config/email_settings.js.dist
@@ -28,49 +28,40 @@ const Nodemailer = require('nodemailer'); // eslint-disable-line no-unused-vars
 
 // const createTransporter = async (clientId, clientSecret, serverUrl, refreshToken) => {
 
-//   try {
-//     const oauth2Client = new OAuth2(
-//       clientId,
-//       clientSecret,
-//       serverUrl
-//     );
+//   const oauth2Client = new OAuth2(clientId, clientSecret, serverUrl);
 
-//     oauth2Client.setCredentials({
-//       refresh_token: refreshToken
-//     });
+//   oauth2Client.setCredentials({ refresh_token: refreshToken });
 
-//     const accessToken = await new Promise((resolve, reject) => {
+//   const accessToken = await new Promise((resolve, reject) => {
 
-//       oauth2Client.getAccessToken((err, token) => {
+//     oauth2Client.getAccessToken((err, token) => {
 
-//         if (err) {
-//           console.log('*ERR: ', err);
-//           reject();
-//         }
-
+//       if (err) {
+//         console.error('*ERR: ', err);
+//         reject(err);
+//       }
+//       else {
 //         resolve(token);
-//       });
-//     });
-
-//     const transporter = Nodemailer.createTransport({
-//       service: 'gmail',
-//       auth: {
-//         type: 'OAuth2',
-//         user: senderAddress,
-//         accessToken,
-//         clientId,
-//         clientSecret,
-//         refreshToken
 //       }
 //     });
-//     return transporter;
-//   }
-//   catch (err) {
-//     return err;
-//   }
+//   });
+
+//   return Nodemailer.createTransport({
+//     service: 'gmail',
+//     auth: {
+//       type: 'OAuth2',
+//       user: senderAddress,
+//       accessToken,
+//       clientId,
+//       clientSecret,
+//       refreshToken
+//     }
+//   });
 // };
 
-// emailTransporter = createTransporter(client_id, client_secret, server_url, refresh_token); // eslint-disable-line no-dupe-keys
+// createTransporter(client_id, client_secret, server_url, refresh_token) // eslint-disable-line no-dupe-keys
+//   .then((t) => { emailTransporter = t; })
+//   .catch((err) => { console.error('Email transporter init failed:', err); });
 
 
 // ------------------------------------------------------------------------- //

--- a/routes/api/v1/auth.js
+++ b/routes/api/v1/auth.js
@@ -160,7 +160,7 @@ exports.plugin = {
 
           const disabledAccountTxt = (disableRegisteringUsers) ? '<p>For security reasons, accounts created via self-registration are disabled by default.  The system adminstrator has been notified of your account request and will enable the account shortly.</p>' : '';
 
-          if (emailTransporter !== null) {
+          if (emailTransporter !== null && typeof emailTransporter.sendMail === 'function') {
             let mailOptions = {
               from: senderAddress,
               to: request.payload.email,
@@ -444,7 +444,7 @@ exports.plugin = {
           <p><a href='${resetLink}'>${resetLink}</a></p>`
         };
 
-        if (emailTransporter !== null) {
+        if (emailTransporter !== null && typeof emailTransporter.sendMail === 'function') {
           emailTransporter.sendMail(mailOptions, (err) => {
 
             if (err) {

--- a/routes/api/v1/users.js
+++ b/routes/api/v1/users.js
@@ -265,7 +265,7 @@ exports.plugin = {
           Boom.serverUnavailable('database error');
         }
 
-        if (emailTransporter !== null) {
+        if (emailTransporter !== null && typeof emailTransporter.sendMail === 'function') {
           const resetLink = `${resetURL}${token}`;
           const mailOptions = {
             from: senderAddress,


### PR DESCRIPTION
## Summary

- The Gmail OAuth2 section in `email_settings.js.dist` assigned an unresolved Promise to `emailTransporter` (`createTransporter` is `async`). Route handlers then called `emailTransporter.sendMail()`, which threw a `TypeError` and returned 500 on `POST /users` and any auth route that sends email.
- Fixed `createTransporter` to reject (not `return`) on error, and changed the activation line to use `.then()/.catch()` so `emailTransporter` stays `null` until the Promise actually resolves.
- Added `typeof emailTransporter.sendMail === 'function'` guard in `auth.js` and `users.js` as a defensive check against a non-transporter value reaching `sendMail`.

## Test plan

- [ ] All 136 existing unit tests pass (`NODE_ENV=test node_modules/.bin/lab`)
- [ ] `POST /users` returns 201 when `emailTransporter` is `null` (default config)
- [ ] With Gmail OAuth2 configured and credentials valid, email is sent after `createTransporter` resolves
- [ ] With invalid OAuth2 credentials, server starts cleanly and logs the init error rather than crashing on first email-sending request

🤖 Generated with [Claude Code](https://claude.com/claude-code)