### PR TITLE
Allow event_button_color in event_template validation

### DIFF
--- a/lib/validations.js
+++ b/lib/validations.js
@@ -368,6 +368,7 @@ const eventTemplateResponse = Joi.object({
   system_template: Joi.boolean(),
   template_categories: Joi.array().items(Joi.string()),
   template_style: Joi.object().optional(),
+  event_button_color: Joi.string().optional(),
   disabled: Joi.boolean().optional(),
   admin_only: Joi.boolean().optional(),
   event_options: Joi.array().items(Joi.object({
@@ -388,6 +389,7 @@ const eventTemplateCreatePayload = Joi.object({
   system_template: Joi.boolean().required(),
   template_categories: Joi.array().items(Joi.string()).optional(),
   template_style: Joi.object(),
+  event_button_color: Joi.string().optional(),
   disabled: Joi.boolean().optional(),
   admin_only: Joi.boolean().optional(),
   event_options: Joi.array().items(Joi.object({
@@ -407,6 +409,7 @@ const eventTemplateUpdatePayload = Joi.object({
   system_template: Joi.boolean().optional(),
   template_categories: Joi.array().items(Joi.string()).optional(),
   template_style: Joi.object().optional(),
+  event_button_color: Joi.string().optional(),
   disabled: Joi.boolean().optional(),
   admin_only: Joi.boolean().optional(),
   event_options: Joi.array().items(Joi.object({


### PR DESCRIPTION
## Summary
- Adds an optional `event_button_color` field to the event template create, update, and response Joi schemas in `lib/validations.js`

## Test plan
- [ ] `npm run lint`
- [ ] Create/update an event template with `event_button_color` set and confirm it round-trips via the API