### PR TITLE
Automatically assign sample ids

### DIFF
--- a/misc/python_sealog/events.py
+++ b/misc/python_sealog/events.py
@@ -27,7 +27,8 @@ from misc.python_sealog.settings import API_SERVER_URL, HEADERS, EVENTS_API_PATH
 from misc.python_sealog._request import _request, _parse
 
 
-def _event_params(export_format, add_record_ids, event_filter, start_ts=None, stop_ts=None):
+def _event_params(export_format, add_record_ids, event_filter, start_ts=None, stop_ts=None,
+                  limit=None):
     '''Build the query params dict for event requests.'''
     event_filter = event_filter or []
     if not isinstance(event_filter, list):
@@ -41,6 +42,8 @@ def _event_params(export_format, add_record_ids, event_filter, start_ts=None, st
         params['startTS'] = start_ts
     if stop_ts is not None:
         params['stopTS'] = stop_ts
+    if limit is not None:
+        params['limit'] = limit
     return params
 
 
@@ -70,7 +73,8 @@ def get_events(export_format='json', add_record_ids=False, event_filter=None,
 
 
 def get_events_by_cruise(cruise_uid, export_format='json', add_record_ids=False,
-                         event_filter=None, api_server_url=API_SERVER_URL, headers=HEADERS):
+                         event_filter=None, limit=None, api_server_url=API_SERVER_URL,
+                         headers=HEADERS):
     '''
     Return event records for the given cruise_uid.  Returns the records as
     json objects by default.  Set export_format to 'csv' to return the records
@@ -78,7 +82,7 @@ def get_events_by_cruise(cruise_uid, export_format='json', add_record_ids=False,
     events.
     '''
     url = api_server_url + EVENTS_API_PATH + '/bycruise/' + cruise_uid
-    params = _event_params(export_format, add_record_ids, event_filter)
+    params = _event_params(export_format, add_record_ids, event_filter, limit=limit)
     return _parse(_request('GET', url, params=params, headers=headers),
                   export_format, collection=True)
 
@@ -103,3 +107,11 @@ def delete_event(event_uid, api_server_url=API_SERVER_URL, headers=HEADERS):
     '''
     url = api_server_url + EVENTS_API_PATH + '/' + event_uid
     _request('DELETE', url, headers=headers)
+
+
+def update_event(event_uid, payload, api_server_url=API_SERVER_URL, headers=HEADERS):
+    '''
+    Update the event record.
+    '''
+    url = api_server_url + EVENTS_API_PATH + '/' + event_uid
+    _request('PATCH', url, payload=payload, headers=headers)

--- a/misc/python_sealog/events.py
+++ b/misc/python_sealog/events.py
@@ -28,7 +28,7 @@ from misc.python_sealog._request import _request, _parse
 
 
 def _event_params(export_format, add_record_ids, event_filter, start_ts=None, stop_ts=None,
-                  limit=None):
+                  limit=None, offset=None, sort=None):
     '''Build the query params dict for event requests.'''
     event_filter = event_filter or []
     if not isinstance(event_filter, list):
@@ -44,6 +44,10 @@ def _event_params(export_format, add_record_ids, event_filter, start_ts=None, st
         params['stopTS'] = stop_ts
     if limit is not None:
         params['limit'] = limit
+    if offset is not None:
+        params['offset'] = offset
+    if sort is not None:
+        params['sort'] = sort
     return params
 
 
@@ -73,8 +77,8 @@ def get_events(export_format='json', add_record_ids=False, event_filter=None,
 
 
 def get_events_by_cruise(cruise_uid, export_format='json', add_record_ids=False,
-                         event_filter=None, limit=None, api_server_url=API_SERVER_URL,
-                         headers=HEADERS):
+                         event_filter=None, limit=None, offset=None, sort=None,
+                         api_server_url=API_SERVER_URL, headers=HEADERS):
     '''
     Return event records for the given cruise_uid.  Returns the records as
     json objects by default.  Set export_format to 'csv' to return the records
@@ -82,7 +86,8 @@ def get_events_by_cruise(cruise_uid, export_format='json', add_record_ids=False,
     events.
     '''
     url = api_server_url + EVENTS_API_PATH + '/bycruise/' + cruise_uid
-    params = _event_params(export_format, add_record_ids, event_filter, limit=limit)
+    params = _event_params(export_format, add_record_ids, event_filter, limit=limit, offset=offset,
+                           sort=sort)
     return _parse(_request('GET', url, params=params, headers=headers),
                   export_format, collection=True)
 

--- a/misc/sealog_auto_actions.py.dist
+++ b/misc/sealog_auto_actions.py.dist
@@ -136,7 +136,7 @@ def _handle_sample_event(event):
                 return
 
             last_sample_event = get_events_by_cruise(
-                cruise['id'], event_filter=EVENT_NAME_SAMPLE, limit=1)
+                cruise['id'], event_filter=EVENT_NAME_SAMPLE, limit=1, sort='newest')
             if last_sample_event and len(last_sample_event) > 0:
                 # If there is a previous sample event, get the sample ID and increment it
                 sample_id_previous = _get_event_option_value(

--- a/misc/sealog_auto_actions.py.dist
+++ b/misc/sealog_auto_actions.py.dist
@@ -32,13 +32,16 @@ import sys
 import asyncio
 import json
 import logging
+import re
 import time
 import websockets
 
 from os.path import dirname, realpath
 sys.path.append(dirname(dirname(realpath(__file__))))
 
+from misc.python_sealog.cruises import get_cruise_by_event
 from misc.python_sealog.custom_vars import get_custom_var_uid_by_name, set_custom_var
+from misc.python_sealog.events import get_events_by_cruise, update_event
 from misc.python_sealog.lowerings import get_lowering_by_event, update_lowering
 from misc.python_sealog.settings import WS_SERVER_URL, HEADERS
 
@@ -47,7 +50,11 @@ ASNAP_STATUS_VAR_NAME = 'asnapStatus'
 # ---------------------------------------------------------
 # For vehicle-focused sealog instances
 # ---------------------------------------------------------
-INCLUDE_SET = ('VEHICLE')  # pylint:disable=C0325
+EVENT_NAME_SAMPLE = 'SAMPLE'
+OPTION_NAME_SAMPLE_ID = 'SAMPLEID'
+PATTERN_SAMPLE_ID = re.compile(r'NA\d{3}-(?P<sample_num>\d{3})')
+
+INCLUDE_SET = ('VEHICLE', EVENT_NAME_SAMPLE)  # pylint:disable=C0325
 
 ASNAP_LOOKUP = {
     'Off deck': 'On',
@@ -103,6 +110,55 @@ PING = {
 }
 
 
+def _handle_sample_event(event):
+    '''
+    The function handles auto actions for sample events.
+    If the sample ID of the event is set to "auto", it will set the sample ID to the next available
+    sample ID for the cruise.
+    '''
+    if event['event_value'] != EVENT_NAME_SAMPLE:
+        return
+
+    logging.debug("Applying auto actions to sample event: %s", json.dumps(event, indent=2))
+    for i in range(len(event['event_options'])):
+        option = event['event_options'][i]
+        if option['event_option_name'] == OPTION_NAME_SAMPLE_ID:
+            sample_id_current = option['event_option_value']
+
+            if sample_id_current != 'auto':
+                logging.info("Event %s already has %s set to %s",
+                             event['id'], OPTION_NAME_SAMPLE_ID, sample_id_current)
+                return
+
+            cruise = get_cruise_by_event(event['id'])
+            if cruise is None:
+                logging.error("No cruise found for event %s", event['id'])
+                return
+
+            last_sample_event = get_events_by_cruise(
+                cruise['id'], event_filter=EVENT_NAME_SAMPLE, limit=1)
+            if last_sample_event and len(last_sample_event) > 0:
+                # If there is a previous sample event, get the sample ID and increment it
+                sample_id_previous = _get_event_option_value(
+                    last_sample_event[0], OPTION_NAME_SAMPLE_ID)
+                match = PATTERN_SAMPLE_ID.match(sample_id_previous)
+                if not match:
+                    logging.error("Previous %s %s does not match expected pattern",
+                                  OPTION_NAME_SAMPLE_ID, sample_id_previous)
+                    return
+                sample_num_previous = int(match.group('sample_num'))
+                sample_id_current = f"{cruise['id']}-{sample_num_previous + 1:03d}"
+            else:
+                # If there is no previous sample event, start with 001
+                sample_id_current = f"{cruise['id']}-001"
+
+            # Update the event in the db
+            logging.debug("Setting %s for event %s to %s",
+                          OPTION_NAME_SAMPLE_ID, event['id'], sample_id_current)
+            event['event_options'][i]['event_option_value'] = sample_id_current
+            update_event(event['id'], event)
+
+
 def _handle_vehicle_event(event):
     '''
     The function handle auto actions for the VEHICLE event_value.  It uses the
@@ -113,13 +169,8 @@ def _handle_vehicle_event(event):
     if event['event_value'] != 'VEHICLE':
         return
 
-    milestone = None
-
     # if event has milestone event_option, pass milestone to _set_asnap and _set_milestones
-    for option in event['event_options']:
-        if option['event_option_name'] == "milestone":
-            milestone = option['event_option_value']
-            break
+    milestone = _get_event_option_value(event, "milestone")
 
     if milestone is not None:
         _set_asnap(milestone)
@@ -135,13 +186,8 @@ def _handle_cruise_event(event):
     if event['event_value'] != 'CRUISE':
         return
 
-    milestone = None
-
-    # if event has milestone event_option, pass milestone to _set_asnap and _set_milestones
-    for option in event['event_options']:
-        if option['event_option_name'] == "status":
-            milestone = option['event_option_value']
-            break
+    # if event has milestone event_option, pass milestone to _set_asnap
+    milestone = _get_event_option_value(event, "status")
 
     if milestone is not None:
         _set_asnap(milestone)
@@ -233,6 +279,18 @@ def _set_milestones(event, evt_milestone):
         logging.debug(str(exc))
 
 
+def _get_event_option_value(event, option_name):
+    '''
+    Return the value of the event_option with the name of option_name
+    '''
+
+    for option in event['event_options']:
+        if option['event_option_name'] == option_name:
+            return option['event_option_value']
+
+    return None
+
+
 async def auto_actions():
     '''
     Listen to the new and updated events and respond as instructed based on the
@@ -264,6 +322,7 @@ async def auto_actions():
 
                     _handle_vehicle_event(event)
                     _handle_cruise_event(event)
+                    _handle_sample_event(event)
 
     except websockets.exceptions.InvalidURI as exc:
         logging.error("Invalid URL: %s", WS_SERVER_URL)

--- a/misc/sealog_auto_actions.py.dist
+++ b/misc/sealog_auto_actions.py.dist
@@ -118,7 +118,7 @@ def _get_max_sample_num(sample_events):
     '''
     sample_nums = [0]
     for sample_event in sample_events:
-        sample_id = _get_event_option_value(sample_event, OPTION_NAME_SAMPLE_ID)
+        sample_id = _get_event_option_value(sample_event, OPTION_NAME_SAMPLE_ID.lower())
 
         if not sample_id:
             # if the event is a draft from another user/tab, won't have event options
@@ -154,7 +154,7 @@ def _handle_sample_event(event):
     logging.debug("Applying auto actions to sample event: %s", json.dumps(event, indent=2))
     for i in range(len(event['event_options'])):
         option = event['event_options'][i]
-        if option['event_option_name'] == OPTION_NAME_SAMPLE_ID:
+        if option['event_option_name'] == OPTION_NAME_SAMPLE_ID.lower():
             sample_id_current = option['event_option_value']
 
             if sample_id_current != DEFAULT_SAMPLE_ID:
@@ -171,7 +171,7 @@ def _handle_sample_event(event):
             # The very most recent event will probably be the initial mostly empty draft version of
             # this event, so we need to check multiple
             most_recent_samples = get_events_by_cruise(
-                cruise['id'], event_filter=EVENT_NAME_SAMPLE, limit=5, sort='newest')
+                cruise['id'], event_filter=[EVENT_NAME_SAMPLE], limit=5, sort='newest')
             try:
                 sample_num_previous = _get_max_sample_num(most_recent_samples)
             except ValueError as exc:
@@ -184,7 +184,11 @@ def _handle_sample_event(event):
             logging.debug("Setting %s for event %s to %s",
                           OPTION_NAME_SAMPLE_ID, event['id'], sample_id_current)
             event['event_options'][i]['event_option_value'] = sample_id_current
-            update_event(event['id'], event)
+            # create new event object with just the event options
+            event_update = {
+                'event_options': event['event_options']
+            }
+            update_event(event['id'], event_update)
 
 
 

--- a/misc/sealog_auto_actions.py.dist
+++ b/misc/sealog_auto_actions.py.dist
@@ -322,7 +322,9 @@ async def auto_actions():
 
                     _handle_vehicle_event(event)
                     _handle_cruise_event(event)
-                    _handle_sample_event(event)
+                    sub = msg_obj['path'].split('/')[-1]
+                    if sub == 'updateEvents':
+                        _handle_sample_event(event)
 
     except websockets.exceptions.InvalidURI as exc:
         logging.error("Invalid URL: %s", WS_SERVER_URL)

--- a/misc/sealog_auto_actions.py.dist
+++ b/misc/sealog_auto_actions.py.dist
@@ -53,6 +53,7 @@ ASNAP_STATUS_VAR_NAME = 'asnapStatus'
 EVENT_NAME_SAMPLE = 'SAMPLE'
 OPTION_NAME_SAMPLE_ID = 'SAMPLEID'
 PATTERN_SAMPLE_ID = re.compile(r'NA\d{3}-(?P<sample_num>\d{3})')
+DEFAULT_SAMPLE_ID = 'auto'
 
 INCLUDE_SET = ('VEHICLE', EVENT_NAME_SAMPLE)  # pylint:disable=C0325
 
@@ -110,6 +111,37 @@ PING = {
 }
 
 
+def _get_max_sample_num(sample_events):
+    '''
+    Return the maximum sample number from a list of sample events.  If no
+    sample events are found, return 0.
+    '''
+    sample_nums = [0]
+    for sample_event in sample_events:
+        sample_id = _get_event_option_value(sample_event, OPTION_NAME_SAMPLE_ID)
+
+        if not sample_id:
+            # if the event is a draft from another user/tab, won't have event options
+            logging.debug("Previous sample event %s has no %s set, skipping",
+                          sample_event['id'], OPTION_NAME_SAMPLE_ID)
+            continue
+
+        if sample_id == DEFAULT_SAMPLE_ID:
+            logging.debug("Previous sample event %s has %s set to 'auto', skipping",
+                          sample_event['id'], OPTION_NAME_SAMPLE_ID)
+            continue
+
+        match = PATTERN_SAMPLE_ID.fullmatch(sample_id)
+        if not match:
+            raise ValueError(f"{OPTION_NAME_SAMPLE_ID} {sample_id} for event {sample_event['id']}"
+                             "does not match expected pattern")
+        logging.debug("Previous sample event %s has %s value %s, adding to list",
+                          sample_event['id'], OPTION_NAME_SAMPLE_ID, match.group('sample_num'))
+        sample_nums.append(int(match.group('sample_num')))
+
+    return max(sample_nums)
+
+
 def _handle_sample_event(event):
     '''
     The function handles auto actions for sample events.
@@ -125,7 +157,7 @@ def _handle_sample_event(event):
         if option['event_option_name'] == OPTION_NAME_SAMPLE_ID:
             sample_id_current = option['event_option_value']
 
-            if sample_id_current != 'auto':
+            if sample_id_current != DEFAULT_SAMPLE_ID:
                 logging.info("Event %s already has %s set to %s",
                              event['id'], OPTION_NAME_SAMPLE_ID, sample_id_current)
                 return
@@ -135,28 +167,25 @@ def _handle_sample_event(event):
                 logging.error("No cruise found for event %s", event['id'])
                 return
 
-            last_sample_event = get_events_by_cruise(
-                cruise['id'], event_filter=EVENT_NAME_SAMPLE, limit=1, sort='newest')
-            if last_sample_event and len(last_sample_event) > 0:
-                # If there is a previous sample event, get the sample ID and increment it
-                sample_id_previous = _get_event_option_value(
-                    last_sample_event[0], OPTION_NAME_SAMPLE_ID)
-                match = PATTERN_SAMPLE_ID.match(sample_id_previous)
-                if not match:
-                    logging.error("Previous %s %s does not match expected pattern",
-                                  OPTION_NAME_SAMPLE_ID, sample_id_previous)
-                    return
-                sample_num_previous = int(match.group('sample_num'))
-                sample_id_current = f"{cruise['id']}-{sample_num_previous + 1:03d}"
-            else:
-                # If there is no previous sample event, start with 001
-                sample_id_current = f"{cruise['id']}-001"
+            # Check 5 most recent sample events for the cruise to find the last sample ID
+            # The very most recent event will probably be the initial mostly empty draft version of
+            # this event, so we need to check multiple
+            most_recent_samples = get_events_by_cruise(
+                cruise['id'], event_filter=EVENT_NAME_SAMPLE, limit=5, sort='newest')
+            try:
+                sample_num_previous = _get_max_sample_num(most_recent_samples)
+            except ValueError as exc:
+                logging.error(exc)
+                return
+
+            sample_id_current = f"{cruise['cruise_id']}-{sample_num_previous + 1:03d}"
 
             # Update the event in the db
             logging.debug("Setting %s for event %s to %s",
                           OPTION_NAME_SAMPLE_ID, event['id'], sample_id_current)
             event['event_options'][i]['event_option_value'] = sample_id_current
             update_event(event['id'], event)
+
 
 
 def _handle_vehicle_event(event):

--- a/misc/sealog_auto_actions.py.dist
+++ b/misc/sealog_auto_actions.py.dist
@@ -50,12 +50,7 @@ ASNAP_STATUS_VAR_NAME = 'asnapStatus'
 # ---------------------------------------------------------
 # For vehicle-focused sealog instances
 # ---------------------------------------------------------
-EVENT_NAME_SAMPLE = 'SAMPLE'
-OPTION_NAME_SAMPLE_ID = 'SAMPLEID'
-PATTERN_SAMPLE_ID = re.compile(r'NA\d{3}-(?P<sample_num>\d{3})')
-DEFAULT_SAMPLE_ID = 'auto'
-
-INCLUDE_SET = ('VEHICLE', EVENT_NAME_SAMPLE)  # pylint:disable=C0325
+INCLUDE_SET = ('VEHICLE')  # pylint:disable=C0325
 
 ASNAP_LOOKUP = {
     'Off deck': 'On',
@@ -90,6 +85,29 @@ MILESTONE_LOOKUP = {
 # START_STOP_LOOKUP = {}
 #
 # MILESTONE_LOOKUP = {}
+# ---------------------------------------------------------
+
+
+# ---------------------------------------------------------
+# For automated sample IDs
+# ---------------------------------------------------------
+EVENT_NAME_SAMPLE = 'SAMPLE'
+INCLUDE_SET = (INCLUDE_SET, EVENT_NAME_SAMPLE)  # comment out to avoid auto ID
+OPTION_NAME_SAMPLE_ID = 'SAMPLEID'
+DEFAULT_SAMPLE_ID = 'auto'
+
+# If you aren't usually logging more than one sample at a time, 5 seems to work fine
+# If you are logging multiple samples at a time, you might want to increase this--should be big
+# enough to include any open draft events + the most recent submitted sample + wiggle room
+NUM_SAMPLES_TO_CHECK_FOR_IDS = 5
+
+# Make sure these two patterns match;
+# PATTERN_SAMPLE_ID must be able to parse anything _build_sample_id() produces
+PATTERN_SAMPLE_ID = re.compile(r'NA\d{3}-(?P<sample_num>\d{3})')
+
+
+def _build_sample_id(cruise_id, sample_num):
+    return f"{cruise_id}-{sample_num:03d}"
 # ---------------------------------------------------------
 
 
@@ -133,10 +151,10 @@ def _get_max_sample_num(sample_events):
 
         match = PATTERN_SAMPLE_ID.fullmatch(sample_id)
         if not match:
-            raise ValueError(f"{OPTION_NAME_SAMPLE_ID} {sample_id} for event {sample_event['id']}"
+            raise ValueError(f"{OPTION_NAME_SAMPLE_ID} {sample_id} for event {sample_event['id']} "
                              "does not match expected pattern")
         logging.debug("Previous sample event %s has %s value %s, adding to list",
-                          sample_event['id'], OPTION_NAME_SAMPLE_ID, match.group('sample_num'))
+                      sample_event['id'], OPTION_NAME_SAMPLE_ID, match.group('sample_num'))
         sample_nums.append(int(match.group('sample_num')))
 
     return max(sample_nums)
@@ -155,11 +173,11 @@ def _handle_sample_event(event):
     for i in range(len(event['event_options'])):
         option = event['event_options'][i]
         if option['event_option_name'] == OPTION_NAME_SAMPLE_ID.lower():
-            sample_id_current = option['event_option_value']
+            sample_id_submitted = option['event_option_value']
 
-            if sample_id_current != DEFAULT_SAMPLE_ID:
+            if sample_id_submitted != DEFAULT_SAMPLE_ID:
                 logging.info("Event %s already has %s set to %s",
-                             event['id'], OPTION_NAME_SAMPLE_ID, sample_id_current)
+                             event['id'], OPTION_NAME_SAMPLE_ID, sample_id_submitted)
                 return
 
             cruise = get_cruise_by_event(event['id'])
@@ -167,29 +185,29 @@ def _handle_sample_event(event):
                 logging.error("No cruise found for event %s", event['id'])
                 return
 
-            # Check 5 most recent sample events for the cruise to find the last sample ID
+            # Check most recent sample events for the cruise to find the last sample ID
             # The very most recent event will probably be the initial mostly empty draft version of
             # this event, so we need to check multiple
             most_recent_samples = get_events_by_cruise(
-                cruise['id'], event_filter=[EVENT_NAME_SAMPLE], limit=5, sort='newest')
+                cruise['id'],
+                event_filter=[EVENT_NAME_SAMPLE],
+                limit=NUM_SAMPLES_TO_CHECK_FOR_IDS,
+                sort='newest')
             try:
                 sample_num_previous = _get_max_sample_num(most_recent_samples)
             except ValueError as exc:
                 logging.error(exc)
                 return
-
-            sample_id_current = f"{cruise['cruise_id']}-{sample_num_previous + 1:03d}"
+            sample_id_new = _build_sample_id(cruise['cruise_id'], sample_num_previous + 1)
 
             # Update the event in the db
             logging.debug("Setting %s for event %s to %s",
-                          OPTION_NAME_SAMPLE_ID, event['id'], sample_id_current)
-            event['event_options'][i]['event_option_value'] = sample_id_current
-            # create new event object with just the event options
+                          OPTION_NAME_SAMPLE_ID, event['id'], sample_id_new)
+            event['event_options'][i]['event_option_value'] = sample_id_new
             event_update = {
                 'event_options': event['event_options']
             }
             update_event(event['id'], event_update)
-
 
 
 def _handle_vehicle_event(event):

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,1 @@
+# make directory importable as a python package so we can run unit tests

--- a/test/misc/__init__.py
+++ b/test/misc/__init__.py
@@ -1,0 +1,1 @@
+# make directory importable as a python package so we can run unit tests

--- a/test/misc/test_sealog_auto_actions.py
+++ b/test/misc/test_sealog_auto_actions.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+'''
+FILE:           sealog_auto_actions.py
+
+DESCRIPTION:    Automated tests for sealog_auto_actions
+
+BUGS:
+NOTES:
+AUTHOR:     Lindsey Jones
+COMPANY:    Ocean Exploration Trust
+VERSION:    1.0
+CREATED:    2026-07-31
+
+LICENSE INFO:   This code is licensed under MIT license (see LICENSE.txt for details)
+                Copyright (C) OceanDataTools.org 2026
+'''
+
+import unittest
+
+from unittest.mock import patch
+
+from misc.sealog_auto_actions import (
+    _handle_sample_event,
+    _get_max_sample_num,
+    EVENT_NAME_SAMPLE,
+    OPTION_NAME_SAMPLE_ID,
+    DEFAULT_SAMPLE_ID,
+    PATTERN_SAMPLE_ID
+)
+
+CRUISE_ID = "NA001"
+
+DB_EVENT_CLICKED_BUT_NOT_SUBMITTED = {'id': '', 'event_options': []}
+
+
+def _build_ws_sample_event(sample_id: str):
+    return {
+        'id': '',
+        'event_value': EVENT_NAME_SAMPLE,
+        'event_options': [
+            {
+                'event_option_name': OPTION_NAME_SAMPLE_ID.lower(),
+                'event_option_value': sample_id
+            }
+        ]
+    }
+
+
+def _build_db_sample_event(sample_id: str):
+    return {
+        'id': '',
+        'event_options': [
+            {'event_option_name': OPTION_NAME_SAMPLE_ID.lower(),
+                'event_option_value': sample_id}
+        ]
+    }
+
+
+class TestAutoSampleId(unittest.TestCase):
+    '''
+    Tests for automatically assigning a sample ID to sample events
+    '''
+
+    def test_get_max_sample_num_no_previous_samples_returns_0(self):
+        '''If there are no previous sample events, _get_max_sample_num should return 0'''
+        self.assertEqual(_get_max_sample_num([]), 0)
+
+    def test_get_max_sample_num_no_valid_previous_samples_returns_0(self):
+        '''
+        If there are previous sample events, but they don't have valid sample IDs,
+        _get_max_sample_num should still return 0
+        '''
+        events = [DB_EVENT_CLICKED_BUT_NOT_SUBMITTED,
+                  _build_db_sample_event("auto")]
+        max_sample_num_observed = _get_max_sample_num(events)
+        self.assertEqual(0, max_sample_num_observed)
+
+    def test_get_max_sample_num_incomplete_sample_events_gets_max_valid(self):
+        '''
+        _get_max_sample_num should return the highest sample ID value, ignoring incomplete events
+        '''
+        max_sample_num_expected = 2
+        events = [DB_EVENT_CLICKED_BUT_NOT_SUBMITTED,
+                  _build_db_sample_event("auto"),
+                  _build_db_sample_event(f"{CRUISE_ID}-001"),
+                  _build_db_sample_event(f"{CRUISE_ID}-{max_sample_num_expected:03d}")]
+        max_sample_num_observed = _get_max_sample_num(events)
+        self.assertEqual(max_sample_num_expected, max_sample_num_observed)
+
+    def test_get_max_sample_num_out_of_order_sample_events_gets_max(self):
+        '''
+        _get_max_sample_num should return the highest sample ID value from the events given,
+        regardless of their order. Events retrieved from the db will be in the order that they were
+        created, but their sample IDs will be in the order they were submitted, so you can't just
+        choose the most recent valid sample ID.
+        '''
+        events = [
+            _build_db_sample_event(f"{CRUISE_ID}-001"),
+            _build_db_sample_event(f"{CRUISE_ID}-003"),
+            _build_db_sample_event(f"{CRUISE_ID}-002"),
+        ]
+        self.assertEqual(_get_max_sample_num(events), 3)
+
+    def test_get_max_sample_invalid_previous_sample_event_throws_error(self):
+        '''
+        If there's a previous event with a sample ID that isn't the default but also doesn't match
+        the pattern, something has gone wrong--throw an error. You have up to
+        NUM_SAMPLES_TO_CHECK_FOR_IDS sample events to fix it until all of the sample numbers get
+        messed up.
+        '''
+        events = [_build_db_sample_event("not-a-valid-id")]
+        with self.assertRaises(ValueError):
+            _get_max_sample_num(events)
+
+    @patch('misc.sealog_auto_actions.update_event')
+    @patch('misc.sealog_auto_actions.get_events_by_cruise')
+    @patch('misc.sealog_auto_actions.get_cruise_by_event')
+    def test_handle_sample_event_no_previous_samples_assigns_001(
+        self,
+        mock_get_cruise_by_event,
+        mock_get_events_by_cruise,
+        mock_update_event
+    ):
+        '''
+        If there are no previous sample events with filled-in IDs, should update current sample
+        event with sample number 1
+        '''
+
+        mock_get_cruise_by_event.return_value = {
+            'id': '',
+            'cruise_id': CRUISE_ID
+        }
+        mock_get_events_by_cruise.return_value = []
+
+        event = _build_ws_sample_event(DEFAULT_SAMPLE_ID)
+        _handle_sample_event(event)
+
+        mock_update_event.assert_called_once()
+        updated_payload = mock_update_event.call_args[0][1]
+        sample_id_observed = updated_payload['event_options'][0]['event_option_value']
+        sample_num_observed = PATTERN_SAMPLE_ID.fullmatch(sample_id_observed).group('sample_num')
+        self.assertEqual(int(sample_num_observed), 1)
+
+    @patch('misc.sealog_auto_actions.update_event')
+    @patch('misc.sealog_auto_actions.get_events_by_cruise')
+    @patch('misc.sealog_auto_actions.get_cruise_by_event')
+    def test_handle_sample_event_previous_sample_event_adds_1(
+        self,
+        mock_get_cruise_by_event,
+        mock_get_events_by_cruise,
+        mock_update_event
+    ):
+        '''
+        If there are previous sample events with filled-in IDs, should update current sample event
+        with max sample number + 1
+        '''
+        mock_get_cruise_by_event.return_value = {
+            'id': '',
+            'cruise_id': CRUISE_ID
+        }
+        mock_get_events_by_cruise.return_value = [
+            _build_db_sample_event(f"{CRUISE_ID}-005")
+        ]
+
+        event = _build_ws_sample_event(DEFAULT_SAMPLE_ID)
+        _handle_sample_event(event)
+
+        mock_update_event.assert_called_once()
+        updated_payload = mock_update_event.call_args[0][1]
+        sample_id_observed = updated_payload['event_options'][0]['event_option_value']
+        sample_num_observed = PATTERN_SAMPLE_ID.fullmatch(sample_id_observed).group('sample_num')
+        self.assertEqual(int(sample_num_observed), 6)
+
+    @patch('misc.sealog_auto_actions.update_event')
+    @patch('misc.sealog_auto_actions.get_events_by_cruise')
+    @patch('misc.sealog_auto_actions.get_cruise_by_event')
+    def test_handle_sample_event_already_has_id_does_not_change(
+        self,
+        mock_get_cruise_by_event,
+        mock_get_events_by_cruise,
+        mock_update_event
+    ):
+        '''
+        If a sample event already has an ID (i.e. the event is being updated for some reason other
+        than initial submission), don't change it
+        '''
+        event = _build_ws_sample_event(f"{CRUISE_ID}-002")
+        _handle_sample_event(event)
+
+        mock_get_cruise_by_event.assert_not_called()
+        mock_get_events_by_cruise.assert_not_called()
+        mock_update_event.assert_not_called()
+
+    @patch('misc.sealog_auto_actions.update_event')
+    @patch('misc.sealog_auto_actions.get_events_by_cruise')
+    @patch('misc.sealog_auto_actions.get_cruise_by_event')
+    def test_handle_sample_event_no_cruise_found_does_not_update(
+        self,
+        mock_get_cruise_by_event,
+        mock_get_events_by_cruise,
+        mock_update_event
+    ):
+        '''
+        If there's no cruise found for the event, it should log an error but not do anything else
+        '''
+        mock_get_cruise_by_event.return_value = None
+
+        event = _build_ws_sample_event(DEFAULT_SAMPLE_ID)
+        with self.assertLogs(level='ERROR') as log:
+            _handle_sample_event(event)
+
+        mock_get_events_by_cruise.assert_not_called()
+        mock_update_event.assert_not_called()
+        self.assertIn('ERROR', log.output[0])
+        self.assertIn('No cruise found', log.output[0])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Uses an auto action to automatically assign the next available sample ID to sample events.

When a _SAMPLE_* event is submitted with the _SAMPLEID_* value "auto"\*, the auto action retrieves the last 5\* sample events for the cruise and find the maximum sample ID value. It then updates the sample ID of the event to this maximum + 1. You can't just check the most recent sample event because that will usually be the empty event created when you click an event button. Checking multiple events also allows for the case where multiple people are logging samples at the same time, though it is important to note that IDs are assigned in the order that events are submitted, not in the order that they are created.
\* customizable 

How to implement:
1. In Sealog, create (or update) a sample event template with a required sample ID option with the default value set to "auto"\*. This should probably be of the _text_ (if you want people to be able to manually edit if needed) or _static text_ type
2. Copy over the new code from misc\sealog_auto_actions.py.dist into misc\sealog_auto_actions.py
3. Update the "For automated sample IDs" config section at the top of the file. At the very least, people will need to update the `PATTERN_SAMPLE_ID`, unless for some reason their cruise IDs also start with "NA"
4. Run the test\misc\test_sealog_auto_actions.py unit tests to check that most of your config is ok
5. Restart the auto_actions service and try submitting a sample event to confirm that your template and your config are aligned

Notes:
- I'm not sure if this will be helpful to other ships or if they already have sample IDs automated, but I thought I would push it just in case. Prior to this change, we were keeping track of sample IDs on a whiteboard and manually typing them in for each sample event.
- It is not ideal that the ID doesn't get filled out until after you submit the event, but this was the simplest method I could think of to automate sample IDs and seemed to fit in best with the existing framework. There are a lot of different ways to solve this problem
- Since there aren't any python unit tests in this repo, I tried to make the ones I added similar to the OpenRVDAS ones

Preview:
Event template example:
<img width="2572" height="1306" src="https://github.com/user-attachments/assets/2470ab42-7658-4203-9c3f-1d077b788a14" />

After submitting event:
<img width="2562" height="1084" src="https://github.com/user-attachments/assets/e861ec9e-684c-4fcf-896c-422f37aab469" />
